### PR TITLE
Fix GH action for spell check and R version consistency

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -67,7 +67,8 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ steps.normalizer.outputs.R_VERSION }}
-          
+          use-public-rspm: true
+
       - name: Restore cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       r-version:
         description: 'The version of R to use'
-        default: '4.2'
+        default: '4.4'
         required: false
         type: string
   push:
@@ -57,7 +57,7 @@ jobs:
           R_VERSION="${{ inputs.r-version }}"
           if [ "$R_VERSION" == "" ]
           then {
-            R_VERSION="4.2"
+            R_VERSION="4.4"
           }
           fi
           echo "::set-output name=R_VERSION::$R_VERSION"

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -69,6 +69,9 @@ jobs:
           r-version: ${{ steps.normalizer.outputs.R_VERSION }}
           use-public-rspm: true
 
+      - name: setup renv
+        uses: r-lib/actions/setup-renv@v2
+          
       - name: Restore cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -86,9 +86,11 @@ jobs:
           renv::install("spelling")
         shell: Rscript {0}
 
+      ########## Run spellcheck on directory of R scripts ##########
       - name: Run Spellcheck
         run: |
-          (spell_errors <- spelling::spell_check_package())
+          input_files <- list.files("pilot5-submission/pilot5-programs", pattern = "\\.(r|Rmd)$", full.names = TRUE)
+          (spell_errors <- spelling::spell_check_files(input_files))
           if (nrow(spell_errors) > 0L) {
             quit(save = "no", status = 1, runLast = FALSE)
           }

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -83,9 +83,7 @@ jobs:
           
       - name: Install Dependencies
         run: |
-          if (!requireNamespace("spelling", quietly = TRUE)) {
-            install.packages("spelling")
-          }
+          renv::install("spelling")
         shell: Rscript {0}
 
       - name: Run Spellcheck

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Normalize inputs
         id: normalizer
         run: |
-          R_VERSION="${{ inputs.r-version }}"
+          R_VERSION="${{ github.event.inputs.r-version }}"
           if [ "$R_VERSION" == "" ]
           then {
             R_VERSION="4.4"

--- a/renv.lock
+++ b/renv.lock
@@ -4,7 +4,7 @@
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "http://rspm/default/latest"
+        "URL": "https://packagemanager.posit.co/cran"
       }
     ]
   },


### PR DESCRIPTION
This PR fixes the issues causing the spellcheck GitHub action to fail during R and package installation. Here is a brief summary of the updates:

* The default R version was still set to 4.2 while the version used in `renv.lock` is 4.4. Now the default version in the action is 4.4, and we should make the rest of the actions consistent if possible.
* The repository referenced in the `renv.lock` file appeared to be a legacy URL of the Posit Package Manager (PPM). I have since updated it to a more secure `https` version of the URL that is also used by the current version of `{renv}`.
* Enforced the use of PPM in the setup-R workflow step to ensure consistency.
* Minor fix to the parameter specification for applying the specified version of R used in the workflow inputs.
* Add a new workflow step specific to bootstrapping `{renv}` itself.
* Use the `renv::install("spelling")` method of installing the `{spelling}` package.
* Run the spell checks on the `pilot5-programs` directory and only include the R and Rmd files. 