### PR TITLE
Temporarily disable selected GH actions

### DIFF
--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -1,10 +1,10 @@
 name: Check URLs 🔗
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main, devel]
+on: workflow_dispatch
+#  push:
+#    branches: [main]
+#  pull_request:
+#    branches: [main, devel]
 
 jobs:
   links:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,5 @@
 on:
   workflow_dispatch:
-  workflow_call:
     inputs:
       r-version:
         description: 'The version of R to use'
@@ -12,12 +11,12 @@ on:
         default: 'false'
         required: false
         type: string
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+#  push:
+#    branches:
+#      - main
+#  pull_request:
+#    branches:
+#      - main
 
 name: Check Lint
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,6 +1,5 @@
 on:
   workflow_dispatch:
-  workflow_call:
     inputs:
       r-version:
         description: 'The version of R to use'
@@ -18,11 +17,11 @@ on:
         required: false
         type: string
 
-  push:
-    branches:
-      - main
-      - devel
-      - pre-release
+#  push:
+#    branches:
+#      - main
+#      - devel
+#      - pre-release
 
 name: Documentation
 

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -10,14 +10,14 @@ on:
         default: '4.4'
         required: false
         type: string
-  push:
-    branches:
-      - main
-      - devel
-  pull_request:
-    branches:
-      - main
-      - devel
+#  push:
+#    branches:
+#      - main
+#      - devel
+#  pull_request:
+#    branches:
+#      - main
+#      - devel
 
 
 concurrency:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,21 +3,20 @@ name: Check Code Style
 
 on:
   workflow_dispatch:
-  workflow_call:
     inputs:
       r-version:
         description: 'The version of R to use'
         default: '4.2'
         required: false
         type: string
-  push:
-    branches:
-      - main
-      - devel
-  pull_request:
-    branches:
-      - main
-      - devel
+#  push:
+#    branches:
+#      - main
+#      - devel
+#  pull_request:
+#    branches:
+#      - main
+#      - devel
 
 
 concurrency:


### PR DESCRIPTION
This PR temporarily removes the events of `push` and `pull_request` for the GH actions which need a refactor before re-enabling.