### PR TITLE
fix: add id flag to quarto publish html command

### DIFF
--- a/.github/workflows/publish-adrg.yaml
+++ b/.github/workflows/publish-adrg.yaml
@@ -46,7 +46,7 @@ jobs:
           env:
             QUARTO_PUB_AUTH_TOKEN: ${{ secrets.QUARTO_PUB_AUTH_TOKEN }}
           run: |
-            nix-shell --run "quarto publish quarto-pub adrg/adrg-quarto-html.qmd --no-browser"
+            nix-shell --run "quarto publish --no-prompt --no-browser --id 91e55c70-e667-47c8-ae39-bd0284b68ca8 adrg/adrg-quarto-html.qmd"
           shell: bash
             
   

--- a/.github/workflows/publish-ectd-bundle.yaml
+++ b/.github/workflows/publish-ectd-bundle.yaml
@@ -50,7 +50,7 @@ jobs:
           env:
             QUARTO_PUB_AUTH_TOKEN: ${{ secrets.QUARTO_PUB_AUTH_TOKEN }}
           run: |
-            nix-shell --run 'cd adrg; quarto publish --no-prompt --no-browser adrg-quarto-html.qmd'
+            nix-shell --run "quarto publish --no-prompt --no-browser -id 91e55c70-e667-47c8-ae39-bd0284b68ca8 adrg/adrg-quarto-html.qmd"
   
         - name: Render ECTD README (custom)
           if: ${{ false }}


### PR DESCRIPTION
Title says it all ... I forgot a parameter in the `quarto publish` command for the HTML version of the ADRG. I've tested the fix locally so I'll go ahead and get this merged in now.